### PR TITLE
Add service setup docs and script

### DIFF
--- a/docs/laravel_service_setup.md
+++ b/docs/laravel_service_setup.md
@@ -1,0 +1,69 @@
+# Running POSDEMO as a Background Service
+
+This guide outlines how to start the Laravel application automatically after a reboot, build front-end assets, clear caches, and serve the app securely with Nginx and SSL.
+
+## 1. Build CSS and JS
+Use the helper script `scripts/bootstrap_laravel.sh` to install dependencies and compile assets for each module. Run it once during deployment and whenever assets change:
+
+```bash
+bash scripts/bootstrap_laravel.sh
+```
+
+## 2. Systemd Service
+Create `/etc/systemd/system/posdemo.service` with the contents below. Adjust paths if the project resides elsewhere.
+
+```ini
+[Unit]
+Description=POSDEMO Laravel Service
+After=network.target
+
+[Service]
+Type=simple
+User=www-data
+WorkingDirectory=/var/www/posdemo
+ExecStart=/usr/bin/php artisan queue:work --sleep=3 --tries=3
+ExecStartPost=/usr/bin/bash /var/www/posdemo/scripts/bootstrap_laravel.sh
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Enable and start the service:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable posdemo.service
+sudo systemctl start posdemo.service
+```
+
+## 3. Nginx and SSL
+Install Nginx and configure it to serve the `public/` directory. A minimal configuration looks like:
+
+```nginx
+server {
+    listen 80;
+    server_name example.com;
+    root /var/www/posdemo/public;
+
+    location / {
+        try_files $uri $uri/ /index.php?$query_string;
+    }
+
+    location ~ \.php$ {
+        include snippets/fastcgi-php.conf;
+        fastcgi_pass unix:/var/run/php/php-fpm.sock;
+    }
+}
+```
+
+For HTTPS with Let's Encrypt:
+
+```bash
+sudo apt-get install certbot python3-certbot-nginx
+sudo certbot --nginx -d example.com
+```
+
+Certbot will update the Nginx configuration to include TLS certificates and set up automatic renewal.
+
+Once configured, Nginx starts automatically on boot, and `posdemo.service` ensures Laravel queues and caches are prepared after each reboot.

--- a/readme.md
+++ b/readme.md
@@ -13,3 +13,7 @@ If you discover a security vulnerability within ultimate POS, please send an e-m
 ## License
 
 The Ultimate POS software is licensed under the [Codecanyon license](https://codecanyon.net/licenses/standard).
+
+## Running as a Service
+
+See [docs/laravel_service_setup.md](docs/laravel_service_setup.md) for steps to build assets, clear caches, and configure a systemd service with Nginx and SSL.

--- a/scripts/bootstrap_laravel.sh
+++ b/scripts/bootstrap_laravel.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Build assets, clear caches, and restart services for POSDEMO Laravel application.
+# Run as root or using sudo where necessary.
+
+set -e
+
+APP_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$APP_ROOT"
+
+# Build CSS/JS assets for each module
+for module in Modules/*; do
+  if [[ -f "$module/package.json" ]]; then
+    echo "Building assets in $module"
+    (cd "$module" && npm install && npm run prod)
+  fi
+done
+
+# Clear and rebuild Laravel caches
+php artisan config:clear
+php artisan cache:clear
+php artisan route:clear
+php artisan view:clear
+php artisan config:cache
+php artisan route:cache
+php artisan view:cache
+
+# Restart services if systemd is available
+if command -v systemctl >/dev/null 2>&1; then
+  sudo systemctl restart php-fpm || true
+  sudo systemctl restart nginx || true
+fi


### PR DESCRIPTION
## Summary
- document how to run the app as a systemd service with nginx and ssl
- add helper script that builds assets and clears caches
- mention new docs in the README

## Testing
- `composer install --no-interaction --no-scripts` *(fails: command not found)*
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68586fcfd8088323abe70f56237d69c3