### PR TITLE
💄 Improve POS layout styling

### DIFF
--- a/Modules/Essentials/Resources/views/attendance/clock_in_clock_out_modal.blade.php
+++ b/Modules/Essentials/Resources/views/attendance/clock_in_clock_out_modal.blade.php
@@ -1,27 +1,29 @@
 <div class="modal fade" id="clock_in_clock_out_modal" tabindex="-1" role="dialog" 
         aria-labelledby="gridSystemModalLabel">
-    <div class="modal-dialog" role="document">
-	  <div class="modal-content">
+    <div class="modal-dialog modal-dialog-centered" role="document">
+          <div class="modal-content rounded-lg shadow-lg border-0">
 
 	    {!! Form::open(['url' => action([\Modules\Essentials\Http\Controllers\AttendanceController::class, 'clockInClockOut']), 'method' => 'post', 'id' => 'clock_in_clock_out_form' ]) !!}
-	    <div class="modal-header">
-	      	<button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-	      	<h4 class="modal-title"><span id="clock_in_text">@lang( 'essentials::lang.clock_in' )</span>
-	      	<span id="clock_out_text">@lang( 'essentials::lang.clock_out' )</span></h4>
-	    </div>
-	    <div class="modal-body">
+            <div class="modal-header bg-light border-b">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title text-lg font-semibold">
+                    <span id="clock_in_text">@lang( 'essentials::lang.clock_in' )</span>
+                    <span id="clock_out_text">@lang( 'essentials::lang.clock_out' )</span>
+                </h4>
+            </div>
+            <div class="modal-body p-4">
 	    	<div class="row">
 	    		<input type="hidden" name="type" id="type">
 		      	<div class="form-group col-md-12">
 		      		<strong>@lang( 'essentials::lang.ip_address' ): {{$ip_address}}</strong>
 		      	</div>
-		      	<div class="form-group col-md-12 clock_in_note @if(!empty($clock_in)) hide @endif">
-		        	{!! Form::label('clock_in_note', __( 'essentials::lang.clock_in_note' ) . ':') !!}
-		        	{!! Form::textarea('clock_in_note', null, ['class' => 'form-control', 'placeholder' => __( 'essentials::lang.clock_in_note'), 'rows' => 3 ]); !!}
-		      	</div>
-		      	<div class="form-group col-md-12 clock_out_note @if(empty($clock_in)) hide @endif">
-		        	{!! Form::label('clock_out_note', __( 'essentials::lang.clock_out_note' ) . ':') !!}
-		        	{!! Form::textarea('clock_out_note', null, ['class' => 'form-control', 'placeholder' => __( 'essentials::lang.clock_out_note'), 'rows' => 3 ]); !!}
+                        <div class="form-group col-md-12 clock_in_note @if(!empty($clock_in)) hide @endif">
+                                {!! Form::label('clock_in_note', __( 'essentials::lang.clock_in_note' ) . ':') !!}
+                                {!! Form::textarea('clock_in_note', null, ['class' => 'form-control rounded', 'placeholder' => __( 'essentials::lang.clock_in_note'), 'rows' => 3 ]); !!}
+                        </div>
+                        <div class="form-group col-md-12 clock_out_note @if(empty($clock_in)) hide @endif">
+                                {!! Form::label('clock_out_note', __( 'essentials::lang.clock_out_note' ) . ':') !!}
+                                {!! Form::textarea('clock_out_note', null, ['class' => 'form-control rounded', 'placeholder' => __( 'essentials::lang.clock_out_note'), 'rows' => 3 ]); !!}
 		      	</div>
 		      	<input type="hidden" name="clock_in_out_location" id="clock_in_out_location" value="">
 	    	</div>
@@ -42,10 +44,10 @@
 		    @endif
 	    </div>
 
-	    <div class="modal-footer">
-	      <button type="submit" class="tw-dw-btn tw-dw-btn-primary tw-text-white">@lang( 'messages.submit' )</button>
-	      <button type="button" class="tw-dw-btn tw-dw-btn-neutral tw-text-white" data-dismiss="modal">@lang( 'messages.close' )</button>
-	    </div>
+            <div class="modal-footer bg-light border-t p-3">
+              <button type="submit" class="tw-dw-btn tw-dw-btn-primary tw-text-white tw-px-4 tw-py-2 tw-rounded">@lang( 'messages.submit' )</button>
+              <button type="button" class="tw-dw-btn tw-dw-btn-neutral tw-text-white tw-px-4 tw-py-2 tw-rounded" data-dismiss="modal">@lang( 'messages.close' )</button>
+            </div>
 
 	    {!! Form::close() !!}
 

--- a/Modules/Essentials/Resources/views/attendance/index.blade.php
+++ b/Modules/Essentials/Resources/views/attendance/index.blade.php
@@ -24,11 +24,11 @@
         </div>     
     @endif
     @if($is_employee_allowed)
-        <div class="row">
-            <div class="col-md-12 text-center">
-                <button 
-                    type="button" 
-                    class="btn btn-app bg-blue clock_in_btn
+        <div class="row mb-4">
+            <div class="col-md-12 text-center space-x-2">
+                <button
+                    type="button"
+                    class="tw-dw-btn tw-dw-btn-primary clock_in_btn mx-1
                         @if(!empty($clock_in))
                             hide
                         @endif
@@ -37,14 +37,13 @@
                     >
                     <i class="fas fa-arrow-circle-down"></i> @lang('essentials::lang.clock_in')
                 </button>
-            &nbsp;&nbsp;&nbsp;
-                <button 
-                    type="button" 
-                    class="btn btn-app bg-yellow clock_out_btn
+                <button
+                    type="button"
+                    class="tw-dw-btn tw-dw-btn-warning clock_out_btn mx-1
                         @if(empty($clock_in))
                             hide
                         @endif
-                    "  
+                    "
                     data-type="clock_out"
                     >
                     <i class="fas fa-hourglass-half fa-spin"></i> @lang('essentials::lang.clock_out')

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -27,8 +27,9 @@
             }
         }
     @endphp
-    <div class="row">
-        <div class="col-md-4">
+    <div class="container mx-auto py-10">
+    <div class="row justify-content-center">
+        <div class="col-md-4 mb-4">
         @if (config('app.env') == 'demo')
         
                 @component('components.widget', [
@@ -105,12 +106,12 @@
         
     @endif
         </div>
-        <div class="col-md-4">
+        <div class="col-md-4 mx-auto">
             <div
-                class="tw-p-5 md:tw-p-6 tw-mb-4 tw-rounded-2xl tw-transition-all tw-duration-200 tw-bg-white tw-shadow-sm tw-ring-1 tw-ring-gray-200">
+                class="tw-p-6 tw-space-y-4 tw-rounded-2xl tw-bg-white tw-shadow-md tw-border tw-border-gray-200 tw-transition-all tw-duration-200">
                 <div class="tw-flex tw-flex-col tw-gap-4 tw-dw-rounded-box tw-dw-p-6 tw-dw-max-w-md">
                     <div class="tw-flex tw-items-center tw-flex-col">
-                        <h1 class="tw-text-lg md:tw-text-xl tw-font-semibold tw-text-[#1e1e1e]">
+                        <h1 class="tw-text-xl md:tw-text-2xl tw-font-bold tw-text-[#1e1e1e]">
                             @lang('lang_v1.welcome_back')
                         </h1>
                         <h2 class="tw-text-sm tw-font-medium tw-text-gray-500">
@@ -215,7 +216,7 @@
                 </div>
             </div>
         </div>
-        <div class="col-md-4"></div>
+    </div>
     </div>
 
 @stop


### PR DESCRIPTION
## Summary
- modernize login layout and center the card
- update clock in/out modal with tailwind styling
- tweak attendance screen buttons

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68587822fec883238a1166ab328d3c9a